### PR TITLE
clientId must be a URI

### DIFF
--- a/scripts/updateClientId.ts
+++ b/scripts/updateClientId.ts
@@ -33,7 +33,7 @@ const clientSecret = process.env.CLIENT_SECRET;
 // build client id doc
 const clientIdDoc = buildClientIdentifierDoc(
   "http://localhost:3000/",
-  clientId as string
+  CLIENT_ID_DOC_IRI
 );
 
 async function updateClientId() {


### PR DESCRIPTION
# ClientId in buildClientIdDoc must be URI

## Description of changes
To build the client id document the clientid passed must be the Client id document URI 

## User testing instructions

## Commit checklist

- [ ] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality, accessibility and prevent regressions, including E2E tests for supported browsers.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] A changeset version has been created, if applicable.
- [ ] Meets Inrupt coding standards and adheres to commit conventions.

## Design requirements checklist

- [ ] Meets Inrupt API Design and UX standards
- [ ] Is responsive to our documented minimum supported screen size + resolution
- [ ] Code is extensible by external contributors or anyone forking
