### PR TITLE
Use VERCEL_URL in client ID generation

### DIFF
--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -28,8 +28,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(405).send("Method Not Allowed");
   }
 
-  const clientId = new URL("/api/app", `https://${req.headers.host}`);
-  const hostname = new URL("/", `https://${req.headers.host}`);
+  const clientId = new URL("/api/app", `https://${process.env.VERCEL_URL}`);
+  const hostname = new URL("/", `https://${process.env.VERCEL_URL}`);
 
   const acceptedType = accepts(req).type([
     "application/ld+json",


### PR DESCRIPTION
# Use VERCEL_URL in client ID generation

## Description of changes

Rather than using a client-supplied header (which is subject to manipulation), the client ID document generation is driven by the configured next.js environment value.

## User testing instructions

## Commit checklist

- [ ] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality, accessibility and prevent regressions, including E2E tests for supported browsers.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] A changeset version has been created, if applicable.
- [ ] Meets Inrupt coding standards and adheres to commit conventions.

## Design requirements checklist

- [ ] Meets Inrupt API Design and UX standards
- [ ] Is responsive to our documented minimum supported screen size + resolution
- [ ] Code is extensible by external contributors or anyone forking
