### PR TITLE
Use VERCEL_BRANCH_URL for preview and PROD_DOMAIN for production

### DIFF
--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -28,15 +28,15 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(405).send("Method Not Allowed");
   }
 
-  let hostname;
+  let domain;
   if (process.env.VERCEL_ENV === "production") {
-      hostname = process.env.PROD_DOMAIN;
+    domain = process.env.PROD_DOMAIN;
   } else {
-      hostname = process.env.VERCEL_BRANCH_URL;
+    domain = process.env.VERCEL_BRANCH_URL;
   }
 
-  const clientId = new URL("/api/app", `https://${hostname}`);
-  const hostname = new URL("/", `https://${hostname}`);
+  const clientId = new URL("/api/app", `https://${domain}`);
+  const hostname = new URL("/", `https://${domain}`);
 
   const acceptedType = accepts(req).type([
     "application/ld+json",

--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -29,10 +29,10 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   let hostname;
-  if (${process.env.VERCEL_ENV} === "production") {
-      hostname = ${process.env.PROD_DOMAIN};
+  if (process.env.VERCEL_ENV === "production") {
+      hostname = process.env.PROD_DOMAIN;
   } else {
-      hostname = ${process.env.VERCEL_BRANCH_URL};
+      hostname = process.env.VERCEL_BRANCH_URL;
   }
 
   const clientId = new URL("/api/app", `https://${hostname}`);

--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -28,8 +28,15 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(405).send("Method Not Allowed");
   }
 
-  const clientId = new URL("/api/app", `https://${req.headers.host}`);
-  const hostname = new URL("/", `https://${req.headers.host}`);
+  let hostname;
+  if (${process.env.VERCEL_ENV} === "production") {
+      hostname = ${process.env.PROD_DOMAIN};
+  } else {
+      hostname = ${process.env.VERCEL_BRANCH_URL};
+  }
+
+  const clientId = new URL("/api/app", `https://${hostname}`);
+  const hostname = new URL("/", `https://${hostname}`);
 
   const acceptedType = accepts(req).type([
     "application/ld+json",

--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -32,7 +32,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (process.env.VERCEL_ENV === "production") {
     domain = process.env.PROD_DOMAIN;
   } else {
-    domain = process.env.VERCEL_BRANCH_URL;
+    domain = process.env.VERCEL_URL;
   }
 
   const clientId = new URL("/api/app", `https://${domain}`);


### PR DESCRIPTION
# Use configuration values for Client ID document URLs

## Description of changes

This makes use of environment variable instead of client-supplied headers in the generation of the client id document.

## User testing instructions

## Commit checklist

- [ ] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality, accessibility and prevent regressions, including E2E tests for supported browsers.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] A changeset version has been created, if applicable.
- [ ] Meets Inrupt coding standards and adheres to commit conventions.

## Design requirements checklist

- [ ] Meets Inrupt API Design and UX standards
- [ ] Is responsive to our documented minimum supported screen size + resolution
- [ ] Code is extensible by external contributors or anyone forking
