### PR TITLE
Ignore eslint major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,21 +4,24 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory.
     directory: "/"
-    # Check the npm registry for updates every day (weekdays).
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
   # Enable version updates for our CI tooling.
   - package-ecosystem: "github-actions"
     # For GitHub Actions, setting the directory to / will check for workflow
     # files in .github/workflows.
     directory: "/"
-    # Check the npm registry for updates every day (weekdays).
     schedule:
       interval: "weekly"
   # Enable version updates for embedded demo app
   - package-ecosystem: "npm"
     # Look for `package.json` and `package-lock.json` files in the `e2e/browser/test-app` directory.
     directory: "/e2e/test-app"
-    # Check the npm registry for updates every day (weekdays).
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The major version upgrades to the eslint dependency requires a more significant refactor of the existing code. For now, this update will be turned off to produce less dependabot noise.