### PR TITLE
Pin GH Actions to SHA hash

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
           name: code-coverage
           path: coverage/
       - name: SonarQube Scan
-        uses: kitabisa/sonarqube-action@v1.2.1
+        uses: kitabisa/sonarqube-action@72254bbe1edac07d7ccfa52eff5ca15fc28bf607 # v1.2.1
         with:
           host: ${{ secrets.SONARQUBE_HOST }}
           login: ${{ secrets.SONARQUBE_DEV_INRUPT_COM_GITHUB_TOKEN }}

--- a/.github/workflows/changeset-version-release.yml
+++ b/.github/workflows/changeset-version-release.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm ci
       - name: Publish release tags and changelogs
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6d3568c53fbe1db6c1f9ab1c7fbf9092bc18627f # v1
         with:
           version: npm run version
           publish: npm run release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           name: code-coverage
           path: coverage/
       - name: SonarQube Scan
-        uses: kitabisa/sonarqube-action@v1.2.1
+        uses: kitabisa/sonarqube-action@72254bbe1edac07d7ccfa52eff5ca15fc28bf607 # v1.2.1
         with:
           host: ${{ secrets.SONARQUBE_HOST }}
           login: ${{ secrets.SONARQUBE_DEV_INRUPT_COM_GITHUB_TOKEN }}


### PR DESCRIPTION
This pins third-party GH actions to commit hashes, as described in the [GitHub Actions documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)