### PR TITLE
SDK-3433: Migrate to sonar cloud

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,8 +22,8 @@ jobs:
           name: code-coverage
           path: coverage/
 
-  sonarqube:
-    name: run sonarqube
+  sonar:
+    name: run sonar analysis
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs: [test]
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
           name: code-coverage
           path: coverage/
       - name: SonarQube Scan
-        uses: kitabisa/sonarqube-action@72254bbe1edac07d7ccfa52eff5ca15fc28bf607 # v1.2.1
-        with:
-          host: ${{ secrets.SONARQUBE_HOST }}
-          login: ${{ secrets.SONARQUBE_DEV_INRUPT_COM_GITHUB_TOKEN }}
+        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           name: code-coverage
           path: coverage/
 
-  sonarqube:
-    name: run sonarqube
+  sonar:
+    name: run sonar analysis
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs: [test]
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
           name: code-coverage
           path: coverage/
       - name: SonarQube Scan
-        uses: kitabisa/sonarqube-action@72254bbe1edac07d7ccfa52eff5ca15fc28bf607 # v1.2.1
-        with:
-          host: ${{ secrets.SONARQUBE_HOST }}
-          login: ${{ secrets.SONARQUBE_DEV_INRUPT_COM_GITHUB_TOKEN }}
+        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=inrupt_AMI
+sonar.projectKey=amc
 sonar.organization=inrupt
 
 # Setting the project name is only needed for monorepo projects. This is how it will show up in the SonarQube dashboard.
-sonar.projectName=ami
+sonar.projectName=Authorization Management Component
 
 # Path is relative to the sonar-project.properties file. Defaults to .
 sonar.sources=src, e2e, pages, scss


### PR DESCRIPTION
This adjusts the CI/CD workflows to use `SonarSource/sonarcloud-github-action` and adjusts the configuration to align with other JS/TS repositories.